### PR TITLE
runtime/pprof: Remove SIGPROF if all events are stopped.

### DIFF
--- a/src/runtime/cpuprof.go
+++ b/src/runtime/cpuprof.go
@@ -63,7 +63,6 @@ const (
 // isSampleAddrIncluded: include the memory address accessed at the time of generating the sample.
 // isKernelIncluded: count the events in the kernel mode.
 // isHvIncluded: count the events in the hypervisor mode.
-// isHvIncluded: include the kernel call chain at the time of the sample.
 // isIdleIncluded: count when the CPU is running the idle task.
 // isSampleCallchainIncluded: include the entire call chain seen at the time of the sample.
 // isCallchainKernelIncluded: include the kernel call chain seen at the time of the sample.

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -4642,7 +4642,7 @@ func setcpuprofileconfig(eventId cpuEvent, profConfig *cpuProfileConfig) {
 			// Restore SIGPROF only if all events are stopped
 			eventsRunning := false
 			for i := _CPUPROF_FIRST_EVENT; i < _CPUPROF_EVENTS_MAX; i++ {
-				if prof[eventId].config != nil {
+				if prof[i].config != nil {
 					eventsRunning = true
 					break
 				}


### PR DESCRIPTION
Fixed a bug.

/cc @chabbimilind 